### PR TITLE
feat(state): ESC exit code and pure isolated profile behavior and UI

### DIFF
--- a/cmd/awsctx/main.go
+++ b/cmd/awsctx/main.go
@@ -13,6 +13,10 @@ import (
 
 func main() {
 	if err := run(os.Args[1:]); err != nil {
+		if errors.Is(err, app.ErrSelectionCanceled) {
+			fmt.Fprintln(os.Stderr, "Error: No profile selected")
+			os.Exit(130)
+		}
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -18,6 +18,7 @@ import (
 )
 
 var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+var ErrSelectionCanceled = errors.New("selection canceled")
 
 type App struct {
 	Settings    config.Settings
@@ -47,7 +48,7 @@ func (a *App) List() error {
 	if err != nil {
 		return err
 	}
-	s, err := state.Load(a.Settings.StateFile)
+	activeProfile, err := a.activeProfile()
 	if err != nil {
 		return err
 	}
@@ -73,7 +74,7 @@ func (a *App) List() error {
 			kind = "sso"
 		}
 		nameCol := fmt.Sprintf("%-*s", nameWidth, p.Name)
-		if p.Name == s.Current {
+		if p.Name == activeProfile {
 			// Match fzf current-profile color for a consistent UX.
 			nameCol = colorizeGreen(nameCol)
 		}
@@ -83,27 +84,27 @@ func (a *App) List() error {
 }
 
 func (a *App) Current() error {
-	s, err := state.Load(a.Settings.StateFile)
+	profile, err := a.activeProfile()
 	if err != nil {
 		return err
 	}
-	if s.Current == "" {
+	if profile == "" {
 		return errors.New("no active profile")
 	}
-	fmt.Fprintf(a.Stdout, "Active Profile: %s\n", s.Current)
+	fmt.Fprintf(a.Stdout, "Active Profile: %s\n", profile)
 	return nil
 }
 
 func (a *App) Env() error {
-	s, err := state.Load(a.Settings.StateFile)
+	profile, err := a.activeProfile()
 	if err != nil {
 		return err
 	}
-	if s.Current == "" {
+	if profile == "" {
 		fmt.Fprintln(a.Stdout, "unset AWS_PROFILE")
 		return nil
 	}
-	fmt.Fprintf(a.Stdout, "export AWS_PROFILE=%s\n", strconv.Quote(s.Current))
+	fmt.Fprintf(a.Stdout, "export AWS_PROFILE=%s\n", strconv.Quote(profile))
 	return nil
 }
 
@@ -173,13 +174,13 @@ func (a *App) UseFZF() error {
 	}
 
 	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
-	currentState, err := state.Load(a.Settings.StateFile)
+	activeProfile, err := a.activeProfile()
 	if err != nil {
 		return err
 	}
 	var b strings.Builder
 	for _, p := range profiles {
-		if p.Name == currentState.Current {
+		if p.Name == activeProfile {
 			// Kubectx-like visual cue: current profile is highlighted in green.
 			b.WriteString("\x1b[32m")
 			b.WriteString(p.Name)
@@ -221,13 +222,13 @@ func (a *App) UseFZF() error {
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 130 {
-			return nil
+			return ErrSelectionCanceled
 		}
 		return fmt.Errorf("fzf selection failed: %w", err)
 	}
 	choice := strings.TrimSpace(string(out))
 	if choice == "" {
-		return errors.New("no profile selected")
+		return errors.New("No profile selected")
 	}
 	choice = ansiEscapePattern.ReplaceAllString(choice, "")
 	return a.UseWithLogin(choice, false)
@@ -483,4 +484,18 @@ func missingFZFMessage() string {
 
 func colorizeGreen(s string) string {
 	return "\x1b[32m" + s + "\x1b[0m"
+}
+
+func (a *App) activeProfile() (string, error) {
+	if p := strings.TrimSpace(os.Getenv("AWS_PROFILE")); p != "" {
+		return p, nil
+	}
+	if p := strings.TrimSpace(os.Getenv("AWS_DEFAULT_PROFILE")); p != "" {
+		return p, nil
+	}
+	s, err := state.Load(a.Settings.StateFile)
+	if err != nil {
+		return "", err
+	}
+	return s.Current, nil
 }

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -23,7 +23,13 @@ AWSCTX_BIN=%s
 awsctx() {
   "$AWSCTX_BIN" "$@" || return $?
   if [ "$#" -eq 0 ] || [ "$1" = "use" ] || [ "$1" = "toggle" ] || [ "$1" = "fzf" ]; then
+    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN AWS_CREDENTIAL_EXPIRATION
     eval "$("$AWSCTX_BIN" env)"
+    if [ -n "${AWS_PROFILE:-}" ]; then
+      export AWS_DEFAULT_PROFILE="$AWS_PROFILE"
+    else
+      unset AWS_DEFAULT_PROFILE
+    fi
   fi
 }
 %s
@@ -41,7 +47,13 @@ AWSCTX_BIN=%s
 awsctx() {
   "$AWSCTX_BIN" "$@" || return $?
   if [ "$#" -eq 0 ] || [ "$1" = "use" ] || [ "$1" = "toggle" ] || [ "$1" = "fzf" ]; then
+    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN AWS_CREDENTIAL_EXPIRATION
     eval "$("$AWSCTX_BIN" env)"
+    if [ -n "${AWS_PROFILE:-}" ]; then
+      export AWS_DEFAULT_PROFILE="$AWS_PROFILE"
+    else
+      unset AWS_DEFAULT_PROFILE
+    fi
   fi
 }
 %s
@@ -60,13 +72,16 @@ function awsctx
   command "$AWSCTX_BIN" $argv
   or return $status
   if test (count $argv) -eq 0; or contains -- $argv[1] use toggle fzf
+    set -e AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN AWS_CREDENTIAL_EXPIRATION
     set -l env_out (command "$AWSCTX_BIN" env 2>/dev/null)
     if string match -q "export AWS_PROFILE=*" -- $env_out
       set -l profile (string replace -r '^export AWS_PROFILE=' '' -- $env_out)
       set profile (string trim -c '"' -- $profile)
       set -gx AWS_PROFILE $profile
+      set -gx AWS_DEFAULT_PROFILE $profile
     else
       set -e AWS_PROFILE
+      set -e AWS_DEFAULT_PROFILE
     end
   end
 end


### PR DESCRIPTION
This PR fixes profile-context behavior and UX around awsctx profile switching, especially for multi-tab usage.

## What Changed

### Fixed fzf cancel flow:
- Esc now returns a dedicated cancel path.
- CLI prints Error: No profile selected.

### Switched active profile resolution to tab-local env first:
- awsctx, awsctx ls, and awsctx current now show the profile relevant to the current shell tab context.

### Why
- Previously, global state and wrapper eval behavior could make tabs appear to “follow” each other unexpectedly.

### Result
- Tabs can remain isolated by profile if users want.
- awsctx, awsctx ls, and awsctx current now show the profile relevant to the current shell tab context.
- Esc in fzf is a clean cancel, not a profile change.